### PR TITLE
Ensure that percentage split evaluations are consistent

### DIFF
--- a/lib/flagsmith_engine.ex
+++ b/lib/flagsmith_engine.ex
@@ -45,7 +45,7 @@ defmodule Flagsmith.Engine do
   end
 
   @doc """
-  Get a specific feature state for a given feature_name in a given 
+  Get a specific feature state for a given feature_name in a given
   `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_environment_feature_state(Environment.t(), name :: String.t()) ::
@@ -54,7 +54,7 @@ defmodule Flagsmith.Engine do
     do: Enum.find(fs, fn %{feature: %{name: f_name}} -> f_name == name end)
 
   @doc """
-  Get list of feature states for a given `t:Flagsmith.Schemas.Identity.t/0` in a 
+  Get list of feature states for a given `t:Flagsmith.Schemas.Identity.t/0` in a
   given `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_identity_feature_states(
@@ -82,7 +82,7 @@ defmodule Flagsmith.Engine do
   end
 
   @doc """
-  Get list of segments for a given `t:Flagsmith.Schemas.Identity.t/0` in a 
+  Get list of segments for a given `t:Flagsmith.Schemas.Identity.t/0` in a
   given `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_identity_segments(
@@ -348,7 +348,7 @@ defmodule Flagsmith.Engine do
       end
 
     Enum.all?(rules, fn rule ->
-      traits_match_segment_rule(traits, rule, segment_id, Identity.composite_key(identity))
+      traits_match_segment_rule(traits, rule, segment_id, identity.django_id || Identity.composite_key(identity))
     end)
   end
 
@@ -487,7 +487,7 @@ defmodule Flagsmith.Engine do
   defp id_to_string(atom) when is_atom(atom), do: Atom.to_string(atom)
 
   @doc """
-  Given an `t:Flagsmith.Schemas.Types.Operator.t/0`, a cast or uncast segment value, and a cast trait 
+  Given an `t:Flagsmith.Schemas.Types.Operator.t/0`, a cast or uncast segment value, and a cast trait
   value, evaluate if the trait value matches to the segment value.
   """
   @spec trait_match(

--- a/lib/flagsmith_engine.ex
+++ b/lib/flagsmith_engine.ex
@@ -348,7 +348,12 @@ defmodule Flagsmith.Engine do
       end
 
     Enum.all?(rules, fn rule ->
-      traits_match_segment_rule(traits, rule, segment_id, identity.django_id || Identity.composite_key(identity))
+      traits_match_segment_rule(
+        traits,
+        rule,
+        segment_id,
+        identity.django_id || Identity.composite_key(identity)
+      )
     end)
   end
 

--- a/lib/flagsmith_engine.ex
+++ b/lib/flagsmith_engine.ex
@@ -45,7 +45,7 @@ defmodule Flagsmith.Engine do
   end
 
   @doc """
-  Get a specific feature state for a given feature_name in a given
+  Get a specific feature state for a given feature_name in a given 
   `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_environment_feature_state(Environment.t(), name :: String.t()) ::
@@ -54,7 +54,7 @@ defmodule Flagsmith.Engine do
     do: Enum.find(fs, fn %{feature: %{name: f_name}} -> f_name == name end)
 
   @doc """
-  Get list of feature states for a given `t:Flagsmith.Schemas.Identity.t/0` in a
+  Get list of feature states for a given `t:Flagsmith.Schemas.Identity.t/0` in a 
   given `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_identity_feature_states(
@@ -82,7 +82,7 @@ defmodule Flagsmith.Engine do
   end
 
   @doc """
-  Get list of segments for a given `t:Flagsmith.Schemas.Identity.t/0` in a
+  Get list of segments for a given `t:Flagsmith.Schemas.Identity.t/0` in a 
   given `t:Flagsmith.Schemas.Environment.t/0`.
   """
   @spec get_identity_segments(
@@ -487,7 +487,7 @@ defmodule Flagsmith.Engine do
   defp id_to_string(atom) when is_atom(atom), do: Atom.to_string(atom)
 
   @doc """
-  Given an `t:Flagsmith.Schemas.Types.Operator.t/0`, a cast or uncast segment value, and a cast trait
+  Given an `t:Flagsmith.Schemas.Types.Operator.t/0`, a cast or uncast segment value, and a cast trait 
   value, evaluate if the trait value matches to the segment value.
   """
   @spec trait_match(

--- a/lib/flagsmith_engine.ex
+++ b/lib/flagsmith_engine.ex
@@ -348,12 +348,7 @@ defmodule Flagsmith.Engine do
       end
 
     Enum.all?(rules, fn rule ->
-      traits_match_segment_rule(
-        traits,
-        rule,
-        segment_id,
-        identity.django_id || Identity.composite_key(identity)
-      )
+      traits_match_segment_rule(traits, rule, segment_id, Identity.composite_key(identity))
     end)
   end
 

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -245,14 +245,15 @@ defmodule Flagsmith.Engine.Test.Generators do
           identity: nil
         }
       ],
-      identifier: nil,
+      identifier: "identifier",
       traits: [
         %Traits.Trait{
           id: 21_852_859,
           trait_key: "show_popup",
           trait_value: %Value{value: false, type: :boolean}
         }
-      ]
+      ],
+      environment_key: "cU3oztxgvRgZifpLepQJTX"
     }
   end
 


### PR DESCRIPTION
It turns out that the Elixir client was already compliant with the issue described in https://github.com/Flagsmith/flagsmith/issues/2186 (see code [here](https://github.com/Flagsmith/flagsmith-elixir-client/blob/main/lib/schemas/identity.ex#L72-L85)). Therefore, this PR only consists of adding more tests to verify that this is definitely the case. 