### PR TITLE
chore: Add `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @flagsmith/flagsmith-back-end


### PR DESCRIPTION
Adds a root `/CODEOWNERS` file with the designated owning team.

Closes #47.
