### PR TITLE
refactor: use release-please markers for version

### DIFF
--- a/lib/flagsmith_client.ex
+++ b/lib/flagsmith_client.ex
@@ -11,10 +11,10 @@ defmodule Flagsmith.Client do
   @doc false
   @spec user_agent() :: String.t()
   def user_agent do
-    case Application.spec(:flagsmith_engine, :vsn) do
-      nil -> "flagsmith-elixir-sdk/unknown"
-      vsn -> "flagsmith-elixir-sdk/#{vsn}"
-    end
+    # x-release-please-start-version
+    version = "2.3.0"
+    # x-release-please-end
+    "flagsmith-elixir-sdk/#{version}"
   end
 
   @doc """

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
             "prerelease": false,
             "include-component-in-tag": false,
             "extra-files": [
+                "lib/flagsmith_client.ex",
                 "test/flagsmith_client_test.exs"
             ]
         }

--- a/test/flagsmith_client_test.exs
+++ b/test/flagsmith_client_test.exs
@@ -439,15 +439,6 @@ defmodule Flagsmith.Client.Test do
   end
 
   describe "User-Agent header" do
-    test "user_agent/0 returns expected version" do
-      # x-release-please-start-version
-      expected_version = "2.3.0"
-      # x-release-please-end
-
-      user_agent = Flagsmith.Client.user_agent()
-      assert user_agent == "flagsmith-elixir-sdk/#{expected_version}"
-    end
-
     test "HTTP client includes User-Agent header", %{config: config} do
       # x-release-please-start-version
       expected_version = "2.3.0"


### PR DESCRIPTION
> [!NOTE]
> This work was authored by Claude (AI assistant) and supervised by @emyller.

This PR refactors the User-Agent version implementation to use release-please markers directly in the code, rather than reading from `Application.spec` at runtime.

Contributes to #49